### PR TITLE
Diverse opmaakdetails + 2 kleine correcties:

### DIFF
--- a/content/uitpas/latest/domeinmodel/balie.md
+++ b/content/uitpas/latest/domeinmodel/balie.md
@@ -17,10 +17,11 @@ Een balie behoort tot één of meerdere permissiegroepen (“UiTPAS groepen”).
 deze balies kunnen pashouders met en zonder kansenstatuut registreren. Zij hebben ook het recht om pashouders zonder INSZ te registreren.
 * **Niet-geautoriseerde registratiebalies**  
 deze balies kunnen pashouders registreren, maar alleen deze zonder kansenstatuut.
-* **Mag personen uit andere gemeentes registreren**
-alleen balies binnen deze permissiegroep mogen pashouders registreren met woonplaats buiten de gemeente van de balie.
+* **Mag MiA-pashouders van een andere gemeente aanmaken**
+alleen balies binnen deze permissiegroep mogen pashouders met kansenstatuut registreren met woonplaats buiten de gemeente van de balie.
 * **Checkin- en ticketbalies**  
 deze balies kunnen pashouders inchecken, voordelen omruilen, en ticket sales doen.
+* **Mag pashouders uit buitenland registreren**
 
 **Baliemedewerkers** ```Optioneel```
 Baliemedewerkers zijn personen die kunnen inloggen op de UiTPAS balie applicatie en naargelang de permissies van de groep waartoe de balie behoort overeenkomstige taken uitvoeren zoals punten toekennen en voordelen omruilen.

--- a/content/uitpas/latest/domeinmodel/coupon.md
+++ b/content/uitpas/latest/domeinmodel/coupon.md
@@ -8,7 +8,7 @@ Coupons zijn geïntroduceerd om tegemoet te komen aan de vereiste om meer flexib
 Coupons laten meer vrijheidsgraden.
 Een pashouder met een coupon, zal recht hebben op een overeenkomstige korting.
 
-Een coupon heeft volgende eigenschappen: 
+Een coupon heeft volgende eigenschappen:
 
 **Naam**
 
@@ -21,13 +21,9 @@ Aantal maal dat een coupon door éénzelfde pashouder kan worden ingezet (over a
 
 Aantal maal dat een coupon op éénzelfde event kan worden ingezet.
 
-**Geldigheidsperiode**
+**Geldigheidsperiode**: Van ... tot..
 
-Van ... tot..
-
-**Verdeling** 
-
-verdeelsleutel die wordt gebruikt als de coupon wordt omgeruild
+**Verdeling**: verdeelsleutel die wordt gebruikt als de coupon wordt omgeruild
 
 **Condities**
 Deze bepalen op welk(e) event(s) de coupon kan ingezet worden.

--- a/content/uitpas/latest/domeinmodel/event.md
+++ b/content/uitpas/latest/domeinmodel/event.md
@@ -42,7 +42,7 @@ calendar type | buy constraint
 -- | --
 1 timestamp | 1 absoluut
 meerdere timestamps | 1 absoluut
-periode | 1 absoluuti
+periode | 1 absoluut
 permanent | 1/week
 
 Aandachtspunt: buy constraints zijn globaal, niet systeemspecifiek. Als een KSB de constraint van een event aanpast, zal deze voor dit event aangepast worden in alle kaartsystemen.

--- a/content/uitpas/latest/domeinmodel/omruilvoordeel.md
+++ b/content/uitpas/latest/domeinmodel/omruilvoordeel.md
@@ -35,7 +35,7 @@ Voordelen worden in de publiekssite gefilterd zodat ze alleen binnen de publicat
 de periode waarbinnen de pashouder het voordeel kan omruilen.
 
 **Geldig voor inwoners van {gemeente}** ```Verplicht```
-indien geen gemeente gespecificeerd dan geldt het omruilvoordeel voor inwoners uit eender welke gemeente)
+indien geen gemeente gespecificeerd dan geldt het omruilvoordeel voor inwoners uit alle gemeentes in het kaartsysteem)
 
 **Kaartsystemen waar dit omruilvoordeel op toepasbaar is** ```Verplicht```
 

--- a/content/uitpas/latest/domeinmodel/pashouder.md
+++ b/content/uitpas/latest/domeinmodel/pashouder.md
@@ -10,9 +10,9 @@ De pashouder heeft volgende eigenschappen:
 **Status** ```Verplicht```
 De status van de pas van de pashouder. Volgende statussen zijn mogelijk: actief, geblokkeerd, verwijderd.
 
-**INSZ** ```Verplicht```
+**INSZ** ```Standaard verplicht```
 Wordt overgenomen van de eID.
-Dit is het rijksregisternummer van de pashouder. Binnen het globale UiTPAS systeem moet het INSZ uniek zijn.
+Dit is het rijksregisternummer van de pashouder. Binnen het globale UiTPAS systeem moet het INSZ uniek zijn. Bijvoorbeeld voor pashouders die in het buitenland wonen, is het INSZ-nummer niet verplicht.
 
 **Woonplaats** ```Verplicht```
 Wordt overgenomen van de eID. De pashouder moet gedomicilieerd zijn in een Belgische gemeente.
@@ -20,7 +20,7 @@ Wordt overgenomen van de eID. De pashouder moet gedomicilieerd zijn in een Belgi
 **Kaartnummer** ```Verplicht```
 Verbindt de pashouder met de kaart via de kaartnummer/chipnummer combinatie.
 
-**Naam** ```Verplicht``` 
+**Naam** ```Verplicht```
 Wordt overgenomen van de eID) Naam en voornaam van de pashouder
 
 **Afbeelding** ```Verplicht```
@@ -33,13 +33,13 @@ Wordt overgenomen van de eID.
 Wordt overgenomen van de eID.
 
 **Geslacht**
-Wordt overgenomen van de eID
+Wordt overgenomen van de eID.
 
 **Nationaliteit**
-Vrij veld
+Vrij veld.
 
 **E-mailadres**
-Vrij veld
+Vrij veld.
 
 **Vereniging**
 Binnen een kaartsysteem kunnen verenigingen worden aangemaakt waar de pashouder lid van kan zijn. Bij het verkrijgen van een lidmaatschap binnen een systeem kan de baliemedewerker aangeven dat de pashouder lid is van deze vereniging tot een bepaalde datum. De geldigheidsdatum kan worden aangepast door een baliemedewerker.

--- a/content/uitpas/latest/domeinmodel/vereniging.md
+++ b/content/uitpas/latest/domeinmodel/vereniging.md
@@ -19,21 +19,18 @@ Een vereniging heeft volgende eigenschappen:
 De periode voorafgaand aan de vervaldatum van het lidmaatschap vanaf wanneer het lidmaatschap van de pashouder verlengd kan worden. Alleen van toepassing op verenigingen met berekeningswijze “Vrij” of “Obv registratiedatum”
 
 **Balie(s) met registratierechten**
-Dit zijn de balies die een pashouder lid kunnen maken voor een bepaalde vereniging. 
+Dit zijn de balies die een pashouder lid kunnen maken voor een bepaalde vereniging.
 
 **Balie(s) met leesrechten**
 Dit zijn de balies die de lidmaatschappen van een pashouder voor de vereniging kunnen zien.
 
-Een lidmaatschap van een pashouder heeft volgende eigenschappen:
+## Een lidmaatschap van een pashouder heeft volgende eigenschappen:
 
 **Einddatum**
 
-**Expired**
-Boolean
+**Expired** ```Boolean```
 
-**Renewdate**.
-De datum vanaf wanneer het lidmaatschap verlengd kan worden.
+**Renewdate** De datum vanaf wanneer het lidmaatschap verlengd kan worden.
 Alleen van toepassing op verenigingen met berekeningswijze “Vrij” of “Obv registratiedatum”
 
-**renewable**
-Boolean
+**Renewable** ```Boolean```

--- a/content/uitpas/latest/domeinmodel/welkomstvoordeel.md
+++ b/content/uitpas/latest/domeinmodel/welkomstvoordeel.md
@@ -35,6 +35,6 @@ De periode waarbinnen de pashouder zich moet registreren om aanspraak te maken o
 De periode waarbinnen de pashouder het voordeel kan opnemen.
 
 **Geldig voor inwoners van {gemeente}** ```Verplicht```
-Indien geen gemeente gespecificeerd dan geldt het welkomstvoordeel voor inwoners uit eender welke gemeente.
+Indien geen gemeente gespecificeerd dan geldt het welkomstvoordeel voor inwoners uit alle gemeentes in het kaartsysteem)
 
-Kaartsystemen waar deze welkomstactie op toepasbaar is ```Verplicht```
+**Kaartsystemen waar deze welkomstactie op toepasbaar is** ```Verplicht```


### PR DESCRIPTION
1. Permissie hernoemd naar "Mag MiA-pashouders van een andere gemeente aanmaken" + "Mag pashouder uit het buitenland registreren"
2. INSZ-nummer is niet altijd verplicht bij een pashouder.