### PR TITLE
Correct lg

### DIFF
--- a/content/search_api_3/latest/searching/offers/name.md
+++ b/content/search_api_3/latest/searching/offers/name.md
@@ -10,9 +10,9 @@ Likewise you can search for `location.name` to find events that take place on a 
 
 |                      | `/offers` | `/events` | `/places` | `/organizers` |
 | -------------------- | --------- | --------- | --------- | ------------- |
-| `name.{lg}`          | x         | x         | x         | x             |
-| `organizer.name.{lg}`|      x    |     x     |     x     |               |
-| `location.name.{lg}` | x         | x         |           |               |
+| `name.{language}`          | x         | x         | x         | x             |
+| `organizer.name.{language}`|      x    |     x     |     x     |               |
+| `location.name.{language}` | x         | x         |           |               |
 
 
 Note: these parameters are not available as a url parameter. 

--- a/content/search_api_3/latest/searching/offers/name.md
+++ b/content/search_api_3/latest/searching/offers/name.md
@@ -8,11 +8,11 @@ Likewise you can search for `location.name` to find events that take place on a 
 
 ## Use
 
-|                      | `/offers` | `/events` | `/places` | `/organizers` |
-| -------------------- | --------- | --------- | --------- | ------------- |
-| `name.{language}`          | x         | x         | x         | x             |
-| `organizer.name.{language}`|      x    |     x     |     x     |               |
-| `location.name.{language}` | x         | x         |           |               |
+|                        | `/offers` | `/events` | `/places` | `/organizers` |
+| --------------------   | --------- | --------- | --------- | ------------- |
+| `name.{lang}`          | x         | x         | x         | x             |
+| `organizer.name.{lang}`|      x    |     x     |     x     |               |
+| `location.name.{lang}` | x         | x         |           |               |
 
 
 Note: these parameters are not available as a url parameter. 


### PR DESCRIPTION
I replaced `{lg}` with `{language}` first but then I saw `{lang}` was already used in the advanced queries reference guide (https://documentatie.uitdatabank.be/content/search_api_3/latest/reference/advanced-queries.html) so I used `{lang}` for consistency. 

The possible confusion with the calendar summary format `lg` should be avoided with this update.