### PR TITLE
Fix faulty JSON example

### DIFF
--- a/content/json-ld/latest/organizers/organizer-create.md
+++ b/content/json-ld/latest/organizers/organizer-create.md
@@ -56,7 +56,7 @@ X-Api-Key: {apiKey}
   "address": {
     "addressCountry": "BE",
     "addressLocality": "Leuven",
-    "postalCode": 3000,
+    "postalCode": "3000",
     "streetAddress": "Sluisstraat 79"
   },
   "contact": [


### PR DESCRIPTION
#### Changed
The value for postalCode into a string ("3000") instead of an integer (3000)